### PR TITLE
Changed blocksize and keysize to subroutines 

### DIFF
--- a/lib/Crypt/XTEA.pm
+++ b/lib/Crypt/XTEA.pm
@@ -54,7 +54,7 @@ Returns the maximum XTEA key size, 16 bytes.
 
 =cut
 
-use constant keysize => $KEY_SIZE;
+sub keysize { $KEY_SIZE }
 
 =method blocksize
 
@@ -62,7 +62,7 @@ Returns the XTEA block size, which is 8 bytes. This function exists so that Cryp
 
 =cut
 
-use constant blocksize => $BLOCK_SIZE;
+sub blocksize { $BLOCK_SIZE }
 
 =method new
 


### PR DESCRIPTION
From an email exchange with Christoph Appel (author of Crypt::ECB):

> The way blocksize() and keysize() are implemented doesn’t work on my platform (perl 5.22.1 on cygwin64 on Windows 7). It seems the constants blocksize and keysize are defined before $KEY_SIZE and $BLOCK_SIZE are initialized. This results in returning undef whenever I call keysize() and blocksize(). I suggest you replace “use constant keysize => $KEY_SIZE” with “sub keysize { $KEY_SIZE }”, like other cipher modules do
